### PR TITLE
docs(site): fix scrollbar was overridden cuz layout issue

### DIFF
--- a/site/apps/Chrome/index.js
+++ b/site/apps/Chrome/index.js
@@ -107,7 +107,7 @@ class Components extends React.Component {
     const title = name === 'intro' ? 'Earth UI' : `${name} ${cn}`
     const tabs = getTabsByComponentName(components, name)
     return (
-      <div>
+      <div className="components__content-top">
         <Header
           className="components__title"
           icon="./svg/app_logo_bg_blue.svg"

--- a/site/apps/Chrome/index.less
+++ b/site/apps/Chrome/index.less
@@ -97,11 +97,13 @@
     }
   }
   &__content-wrapper {
-    height: ~'calc(100vh - @{ui-unit-triple})';
     overflow-y: scroll;
   }
   &__content {
     padding: 70px @ui-unit-triple 140px;
+    &-top {
+      flex-shrink: 0;
+    }
   }
 }
 

--- a/site/widgets/Layout/index.less
+++ b/site/widgets/Layout/index.less
@@ -35,20 +35,13 @@
 .layout__content {
   float: none !important;
   background-color: hsl(195, 19%, 92%);
-  //background-color: #f5f5f5;
   position: absolute;
   left: @ui-width-aside;
   right: 0;
   top: 0;
   bottom: 0;
-
-  // ~ flex: 1;
-  //flex-grow: 1;
-  //flex-basis: 0;
-  //.layout__content-scrollbar {
-  //  overflow: hidden;
-  //  padding: 0 0 140px;
-  //}
+  display: flex;
+  flex-direction: column;
 
   @media (max-width: 768px) {
     width: 100%;

--- a/site/widgets/Layout/index.less
+++ b/site/widgets/Layout/index.less
@@ -7,14 +7,10 @@
 }
 
 .layout__sidebar {
-  position: absolute;
-  float: none !important;
-  top: 0;
-  left: 0;
-  bottom: 0;
+  position: relative;
   background-color: @ui-color-slate;
-  width: @ui-width-aside;
-
+  flex-shrink: 0;
+  flex-basis: @ui-width-aside;
   transition: all .2s;
   font-weight: @ui-fontweight-medium;
   .chinese {
@@ -22,41 +18,18 @@
     margin-left: 6px;
     font-weight: normal;
   }
-  @media (max-width: 768px) {
-    position: absolute;
-    transform: translate(-@ui-width-aside - 2px, 0);
-    height: 100%;
-    background-color: @ui-color-white;
-    z-index: 9999;
-    overflow: auto;
-  }
 }
 
 .layout__content {
-  float: none !important;
-  background-color: hsl(195, 19%, 92%);
-  position: absolute;
-  left: @ui-width-aside;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
-
-  @media (max-width: 768px) {
-    width: 100%;
-    padding-top: 70px;
-  }
+  height: 100vh;
+  background-color: hsl(195, 19%, 92%);
 }
 
 .layout__toggle {
   display: none;
-  @media (max-width: 768px) {
-    display: block;
-    position: absolute;
-    left: 20px;
-    top: 20px;
-  }
 }
 
 .layout--open {

--- a/site/widgets/Layout/index.less
+++ b/site/widgets/Layout/index.less
@@ -9,8 +9,8 @@
 .layout__sidebar {
   position: relative;
   background-color: @ui-color-slate;
+  width: @ui-width-aside;
   flex-shrink: 0;
-  flex-basis: @ui-width-aside;
   transition: all .2s;
   font-weight: @ui-fontweight-medium;
   .chinese {


### PR DESCRIPTION
## Description

修复由于顶部高度不一样，导致部分页面的滚动条在页面底部被覆盖的问题。

正常页面：https://cosmos-x.github.io/earth-ui/#/apps/components/Avatar
异常页面：https://cosmos-x.github.io/earth-ui/#/apps/start/usage

flex测试：https://codepen.io/muwenzi/pen/jjKrrw

## Changes

- 将px-auto的绝对定位布局改成flex布局
- 将右侧内容区上下calc布局布局改成flex布局
- 删除一些不正确的移动端适配内容

## ScreenShots/Gifs

Before:
![bug-1](https://user-images.githubusercontent.com/12554487/60640793-7560c700-9e5b-11e9-8300-537dc4619115.gif)

After:
![bug-2](https://user-images.githubusercontent.com/12554487/60640798-7a257b00-9e5b-11e9-90ac-685e2a7ef846.gif)

