### PR TITLE
build(webpack): disable webpack minification cuz of prod issue

### DIFF
--- a/config/webpack.config.site.js
+++ b/config/webpack.config.site.js
@@ -136,7 +136,9 @@ const config = {
       prefixCls: JSON.stringify('earthui')
     })
   ],
-  optimization: {}
+  optimization: {
+    minimize: false
+  }
 }
 
 if (!isProduction) {


### PR DESCRIPTION
Maybe cuz by webpack tree-shaking or https://webpack.js.org/configuration/optimization/#optimization-usedexports

Reference issue: https://github.com/webpack/webpack/issues/7978